### PR TITLE
Changes to allow installation with python3.11 and newer cmake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,21 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.15.0)
 project(affine_transform)
 
 find_package(OpenMP)
 
-add_subdirectory(extern/pybind11)
+# Use FetchContent to automatically download dependencies
+include(FetchContent)
+FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG v2.13.6
+)
+FetchContent_Declare(
+    eigen
+    GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+    GIT_TAG 3.4.0
+)
+FetchContent_MakeAvailable(pybind11 eigen)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -15,7 +27,7 @@ if(UNIX)
 endif()
 
 pybind11_add_module(_affine_transform src/main.cpp)
-target_include_directories(_affine_transform PUBLIC "extern/eigen")
+target_include_directories(_affine_transform PUBLIC "${eigen_SOURCE_DIR}")  # Use FetchContent path
 target_include_directories(_affine_transform PUBLIC "include")
 
 if(OpenMP_CXX_FOUND)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "cmake"]
+requires = ["setuptools>=61.0", "wheel", "setuptools_scm[toml]>=6.2", "cmake>=3.15"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "affine_transform"
+dynamic = ["version"]
+description = "Easy to use multi-core affine transformations"
+readme = "README.rst"
+license = {text = "MIT"}
+requires-python = ">=3.8"
+authors = [
+    {name = "NOhs, TobelRunner"}
+]
+
+[tool.setuptools_scm]
+write_to = "affine_transform/version.txt"


### PR DESCRIPTION
Hi @NOhs,

I am facing errors when doing `pip install affine-transform` on a clean venv:

```
Building wheel for affine-transform (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for affine-transform (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [113 lines of output]
      /private/var/folders/v3/z59tzjz91f14xjktl585b0j80000gq/T/pip-build-env-6rg8xvzp/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'tests_require'
        warnings.warn(msg)
      /private/var/folders/v3/z59tzjz91f14xjktl585b0j80000gq/T/pip-build-env-6rg8xvzp/overlay/lib/python3.11/site-packages/setuptools/dist.py:761: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:
      
              License :: OSI Approved :: MIT License
      
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      
      !!
        self._finalize_license_expression()
      running bdist_wheel
      running build
      running build_py
      creating build/lib.macosx-14.0-x86_64-cpython-311/affine_transform
      copying affine_transform/__init__.py -> build/lib.macosx-14.0-x86_64-cpython-311/affine_transform
      copying affine_transform/affine_transform.py -> build/lib.macosx-14.0-x86_64-cpython-311/affine_transform
      copying affine_transform/version.txt -> build/lib.macosx-14.0-x86_64-cpython-311/affine_transform
      running build_ext
      CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
        Compatibility with CMake < 3.10 will be removed from a future version of
        CMake.
      
        Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
        to tell CMake that the project requires at least <min> but has been updated
        to work with policies introduced by <max> or earlier.
      
      
      -- The C compiler identification is Clang 19.1.7
      -- The CXX compiler identification is Clang 19.1.7
      -- Detecting C compiler ABI info
      -- Detecting C compiler ABI info - done
      -- Check for working C compiler: /usr/local/opt/llvm/bin/clang - skipped
      -- Detecting C compile features
      -- Detecting C compile features - done
      -- Detecting CXX compiler ABI info
      -- Detecting CXX compiler ABI info - done
      -- Check for working CXX compiler: /usr/local/opt/llvm/bin/clang++ - skipped
      -- Detecting CXX compile features
      -- Detecting CXX compile features - done
      -- Found OpenMP_C: -fopenmp=libomp (found version "5.1")
      -- Found OpenMP_CXX: -fopenmp=libomp (found version "5.1")
      -- Found OpenMP: TRUE (found version "5.1")
      CMake Error at extern/pybind11/CMakeLists.txt:8 (cmake_minimum_required):
        Compatibility with CMake < 3.5 has been removed from CMake.
      
        Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
        to tell CMake that the project requires at least <min> but has been updated
        to work with policies introduced by <max> or earlier.
      
        Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
      
      
      -- Configuring incomplete, errors occurred!
```

After some collaborative debugging with Claude 3.7, the following changes were proposed, which enable installing the package successfully on Python 3.11. Please let me know if you need any other info!

Thank you for the help!